### PR TITLE
feat: [300-stomp_config] stomp 설정 추가

### DIFF
--- a/src/main/java/com/bom/rentalmarket/chatting/config/WebSocketConfig.java
+++ b/src/main/java/com/bom/rentalmarket/chatting/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.bom.rentalmarket.chatting.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/pub")
+            .enableSimpleBroker("/sub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chatting")
+            .setAllowedOriginPatterns("*")
+            .withSockJS();
+    }
+}


### PR DESCRIPTION
Changes
---
registerStompEndPoints
- websocket handshake를 위한 설정
- withSockJs : 소켓을 지원하지 않는 브라우저일 때 sockJS를 사용.

configureMessageBroker
- Stomp 사용을 위한 Message Broker 설정

Background
---
웹소켓 통신 방식 및 Message Broker에 대한 개념 공부
