### PR TITLE
[202]-Rental-Get, Create

### DIFF
--- a/src/main/java/com/bom/rentalmarket/product/controller/ProductController.java
+++ b/src/main/java/com/bom/rentalmarket/product/controller/ProductController.java
@@ -1,14 +1,13 @@
 package com.bom.rentalmarket.product.controller;
 
-import com.bom.rentalmarket.product.entity.ProductBoard;
 import com.bom.rentalmarket.product.model.CreateProductForm;
+import com.bom.rentalmarket.product.model.GetProductDetailForm;
+import com.bom.rentalmarket.product.model.GetProductForm;
 import com.bom.rentalmarket.product.service.ProductService;
 import com.bom.rentalmarket.product.type.CategoryType;
 import com.bom.rentalmarket.product.type.StatusType;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -28,15 +27,24 @@ public class ProductController {
 
 
   @GetMapping
-  public ResponseEntity<Map<String, Object>> getProducts(
+  public ResponseEntity<List<GetProductForm>> getProducts(
       @RequestParam(value = "category-name", required = false) CategoryType categoryName,
       @RequestParam(required = false) StatusType status,
       @RequestParam(required = false) String keyword,
       @RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "10") int size) {
-    Map<String, Object> productList = productService.getProducts(categoryName, status, keyword, page, size);
+    List<GetProductForm> productList = productService.getProducts(categoryName, status, keyword,
+        (long) page, (long) size);
     return ResponseEntity.ok().body(productList);
   }
+
+  //  @GetMapping
+  public ResponseEntity<List<GetProductDetailForm>> getDetailProduct(
+      @RequestParam int id) {
+    List<GetProductDetailForm> productList = productService.getDetailProduct();
+    return null;
+  }
+
 
   @GetMapping("/create")
   public String getCreateProduct() {
@@ -45,28 +53,13 @@ public class ProductController {
   }
 
   @PostMapping("/create")
-  public ResponseEntity<String> createProduct(
+  public ResponseEntity<CreateProductForm> createProduct(
       @ModelAttribute CreateProductForm createProductForm,
-      @RequestParam("imageFiles") MultipartFile[] imageFiles,
+      @RequestParam("imageFiles") List<MultipartFile> imageFiles,
       @RequestParam("mainImageIndex") int mainImageIndex) throws IOException {
 
-    List<MultipartFile> imageFilesOnly = new ArrayList<>();
-    for (MultipartFile file : imageFiles) {
-      String fileType = file.getContentType();
-      String extension = "";
-      if (fileType != null) {
-        extension = fileType.substring(fileType.indexOf('/') + 1);
-      } else {
-        extension = file.getOriginalFilename()
-            .substring(file.getOriginalFilename().lastIndexOf('.') + 1);
-      }
-      if (extension.equals("jpeg") || extension.equals("jpg") || extension.equals("png")
-          || extension.equals("gif")) {
-        imageFilesOnly.add(file);
-      }
-    }
-    ProductBoard rental = productService.createProduct(createProductForm, imageFilesOnly,
+    CreateProductForm addProduct = productService.createProduct(createProductForm, imageFiles,
         mainImageIndex);
-    return ResponseEntity.ok("상품이 등록되었습니다.");
+    return ResponseEntity.ok(addProduct);
   }
 }

--- a/src/main/java/com/bom/rentalmarket/product/converter/StringListConverter.java
+++ b/src/main/java/com/bom/rentalmarket/product/converter/StringListConverter.java
@@ -1,0 +1,28 @@
+package com.bom.rentalmarket.product.converter;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+  private static final String DELIMITER = ",";
+
+  @Override
+  public String convertToDatabaseColumn(List<String> list) {
+    if (list == null) {
+      return null;
+    }
+    return String.join(DELIMITER, list);
+  }
+
+  @Override
+  public List<String> convertToEntityAttribute(String joined) {
+    if (joined == null) {
+      return null;
+    }
+    return Arrays.asList(joined.split(DELIMITER));
+  }
+}

--- a/src/main/java/com/bom/rentalmarket/product/entity/ProductBoard.java
+++ b/src/main/java/com/bom/rentalmarket/product/entity/ProductBoard.java
@@ -1,38 +1,37 @@
 package com.bom.rentalmarket.product.entity;
 
 import com.bom.rentalmarket.common.BaseEntity;
+import com.bom.rentalmarket.product.converter.StringListConverter;
 import com.bom.rentalmarket.product.type.CategoryType;
 import com.bom.rentalmarket.product.type.MaxPeriodType;
 import com.bom.rentalmarket.product.type.StatusType;
 import java.time.LocalDateTime;
 import java.util.List;
-import javax.persistence.ElementCollection;
+import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.envers.AuditOverride;
 
 @Entity
 @Builder
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
-@Table(name = "ProductBoard")
 public class ProductBoard extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "product_id")
   private Long id;
 
   @Enumerated(EnumType.STRING)
@@ -44,13 +43,14 @@ public class ProductBoard extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private StatusType status;
 
-  @ElementCollection
+  @Convert(converter = StringListConverter.class)
   private List<String> imageUrls;
 
   private String mainImageUrl;
 
   private Long unitPrice;
 
+  @Column(name = "seller_id")
   private String sellerId;
 
   private String title;

--- a/src/main/java/com/bom/rentalmarket/product/model/GetProductForm.java
+++ b/src/main/java/com/bom/rentalmarket/product/model/GetProductForm.java
@@ -49,7 +49,5 @@ public class GetProductForm {
         .modifiedAt(productBoard.getModifiedAt())
         .build();
   }
-
-
 }
 

--- a/src/main/java/com/bom/rentalmarket/product/repository/ProductRepository.java
+++ b/src/main/java/com/bom/rentalmarket/product/repository/ProductRepository.java
@@ -5,7 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductRepository extends JpaRepository<ProductBoard, Long> {
-
-
+public interface ProductRepository extends JpaRepository<ProductBoard, Long>, ProductSearch {
 }

--- a/src/main/java/com/bom/rentalmarket/product/repository/ProductSearch.java
+++ b/src/main/java/com/bom/rentalmarket/product/repository/ProductSearch.java
@@ -1,0 +1,11 @@
+package com.bom.rentalmarket.product.repository;
+
+import com.bom.rentalmarket.product.entity.ProductBoard;
+import com.bom.rentalmarket.product.type.CategoryType;
+import com.bom.rentalmarket.product.type.StatusType;
+import java.util.List;
+
+public interface ProductSearch {
+  List<ProductBoard> searchFilters(CategoryType categoryName, StatusType status,
+      String keyword, long pageNo, long pageSize);
+}

--- a/src/main/java/com/bom/rentalmarket/product/repository/ProductSearchImpl.java
+++ b/src/main/java/com/bom/rentalmarket/product/repository/ProductSearchImpl.java
@@ -1,0 +1,49 @@
+package com.bom.rentalmarket.product.repository;
+
+import com.bom.rentalmarket.product.entity.ProductBoard;
+import com.bom.rentalmarket.product.entity.QProductBoard;
+import com.bom.rentalmarket.product.type.CategoryType;
+import com.bom.rentalmarket.product.type.StatusType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductSearchImpl implements ProductSearch{
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public ProductSearchImpl(JPAQueryFactory jpaQueryFactory) {
+    this.jpaQueryFactory = jpaQueryFactory;
+  }
+
+  public List<ProductBoard> searchFilters(CategoryType categoryName, StatusType status,
+      String keyword, long pageNo, long pageSize) {
+    QProductBoard productBoard = QProductBoard.productBoard;
+
+    BooleanBuilder builder = new BooleanBuilder();
+
+    if (categoryName != null) {
+      builder.and(productBoard.categoryName.eq(categoryName));
+    }
+
+    if (status != null) {
+      builder.and(productBoard.status.eq(status));
+    }
+
+    if (keyword != null && !keyword.isEmpty()) {
+      builder.and(productBoard.title.containsIgnoreCase(keyword)
+          .or(productBoard.content.containsIgnoreCase(keyword)));
+    }
+
+    return jpaQueryFactory.selectFrom(productBoard)
+        .where(builder)
+        .orderBy(productBoard.createdAt.desc())
+        .offset((pageNo - 1) * pageSize) // 결과가 int의 범위를 벗어날수도 있기 때문
+        .limit(pageSize)
+        .fetch();
+  }
+
+}
+

--- a/src/main/java/com/bom/rentalmarket/product/service/ProductService.java
+++ b/src/main/java/com/bom/rentalmarket/product/service/ProductService.java
@@ -1,21 +1,17 @@
 package com.bom.rentalmarket.product.service;
 
 import com.bom.rentalmarket.product.entity.ProductBoard;
-import com.bom.rentalmarket.product.entity.QProductBoard;
 import com.bom.rentalmarket.product.model.CreateProductForm;
+import com.bom.rentalmarket.product.model.GetProductDetailForm;
 import com.bom.rentalmarket.product.model.GetProductForm;
 import com.bom.rentalmarket.product.repository.ProductRepository;
 import com.bom.rentalmarket.product.type.CategoryType;
 import com.bom.rentalmarket.product.type.StatusType;
 import com.bom.rentalmarket.s3.S3Service;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,17 +23,29 @@ public class ProductService {
 
   private final ProductRepository productRepository;
   private final S3Service s3Service;
-  private final JPAQueryFactory jpaQueryFactory;
 
-  public ProductBoard createProduct(CreateProductForm form, List<MultipartFile> imageFiles,
+  public CreateProductForm createProduct(CreateProductForm form, List<MultipartFile> imageFiles,
       int mainImageIndex)
       throws IOException {
+
+    // 이미지 파일의 확장자를 체크하여 유효한 파일만 걸러내고, S3에 업로드합니다.
+    List<MultipartFile> validImageFiles = new ArrayList<>();
     List<String> imageUrls = new ArrayList<>();
+    String mainImageUrl = "";
     for (MultipartFile file : imageFiles) {
-      String imageUrl = s3Service.upload(file);
-      imageUrls.add(imageUrl);
+      if (isValidImageExtension(file)) {
+        validImageFiles.add(file);
+        String imageUrl = s3Service.upload(file);
+        imageUrls.add(imageUrl);
+      }
     }
 
+    // 메인 이미지 URL을 구합니다.
+    if (mainImageIndex >= 0 && mainImageIndex < imageUrls.size()) {
+      mainImageUrl = imageUrls.get(mainImageIndex);
+    }
+
+    // ProductBoard 객체를 생성합니다.
     ProductBoard productBoard = ProductBoard.builder()
         .title(form.getTitle())
         .content(form.getContent())
@@ -50,58 +58,54 @@ public class ProductService {
         .createdAt(LocalDateTime.now())
         .modifiedAt(LocalDateTime.now())
         .imageUrls(imageUrls)
+        .mainImageUrl(mainImageUrl)
         .status(StatusType.AVAILABLE)
         .build();
 
-    //대표이미지 추가 부분
-    if (mainImageIndex >= 0 && mainImageIndex < imageUrls.size()) {
-      String mainImageUrl = imageUrls.get(mainImageIndex);
-      productBoard.setMainImageUrl(mainImageUrl);
-    }
+    ProductBoard savedProduct = productRepository.save(productBoard);
 
-    return productRepository.save(productBoard);
+    // ProductBoard 객체를 저장하고 CreateProductForm 객체로 변환하여 리턴합니다.
+    return CreateProductForm.builder()
+        .sellerId(savedProduct.getSellerId())
+        .nickname(savedProduct.getNickname())
+        .title(savedProduct.getTitle())
+        .content(savedProduct.getContent())
+        .imageUrls(savedProduct.getImageUrls())
+        .mainImageUrl(savedProduct.getMainImageUrl())
+        .wishRegion(savedProduct.getWishRegion())
+        .maxRentalPeriod(savedProduct.getMaxRentalPeriod())
+        .categoryName(savedProduct.getCategoryName())
+        .unitPrice(savedProduct.getUnitPrice())
+        .status(savedProduct.getStatus())
+        .createdAt(savedProduct.getCreatedAt())
+        .modifiedAt(savedProduct.getModifiedAt())
+        .build();
   }
 
-  public Map<String, Object> getProducts(CategoryType categoryName, StatusType status,
-      String keyword, int pageNo, int pageSize) {
-    QProductBoard productBoard = QProductBoard.productBoard;
-
-    BooleanBuilder builder = new BooleanBuilder();
-
-    if (categoryName != null) {
-      builder.and(productBoard.categoryName.eq(categoryName));
+  private boolean isValidImageExtension(MultipartFile file) {
+    String fileType = file.getContentType();
+    String extension;
+    if (fileType != null) {
+      extension = fileType.substring(fileType.indexOf('/') + 1);
+    } else {
+      extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf('.') + 1);
     }
-
-    if (status != null) {
-      builder.and(productBoard.status.eq(status));
-    }
-
-    if (keyword != null && !keyword.isEmpty()) {
-      builder.and(productBoard.title.containsIgnoreCase(keyword)
-          .or(productBoard.content.containsIgnoreCase(keyword)));
-    }
-
-    List<ProductBoard> productBoardList = jpaQueryFactory.selectFrom(productBoard)
-        .where(builder)
-        .orderBy(productBoard.createdAt.desc())
-        .offset((pageNo - 1) * pageSize)
-        .limit(pageSize)
-        .fetch();
-
-    boolean hasNextPage = jpaQueryFactory.selectFrom(productBoard)
-        .where(builder)
-        .offset(pageNo * pageSize)
-        .limit(1)
-        .fetch()
-        .isEmpty();
-
-    Map<String, Object> result = new HashMap<>();
-    result.put("productList",
-        productBoardList.stream().map(GetProductForm::from).collect(Collectors.toList()));
-    result.put("hasNextPage", !hasNextPage);
-
-    return result;
+    return extension.equals("jpeg") || extension.equals("jpg") || extension.equals("png") || extension.equals("gif");
   }
 
+
+  public List<GetProductForm> getProducts(CategoryType categoryName, StatusType status,
+      String keyword, Long pageNo, Long pageSize) {
+
+    List<ProductBoard> productBoardList = productRepository.searchFilters(categoryName,
+        status, keyword, pageNo, pageSize);
+
+    return productBoardList.stream().map(GetProductForm::from).collect(Collectors.toList());
+  }
+
+  public List<GetProductDetailForm> getDetailProduct() {
+
+    return null;
+  }
 }
 

--- a/src/test/java/com/bom/rentalmarket/product/service/ProductGetServiceTest.java
+++ b/src/test/java/com/bom/rentalmarket/product/service/ProductGetServiceTest.java
@@ -2,7 +2,6 @@ package com.bom.rentalmarket.product.service;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.bom.rentalmarket.product.model.GetProductForm;
 import com.bom.rentalmarket.product.repository.ProductRepository;
@@ -10,7 +9,6 @@ import com.bom.rentalmarket.product.type.CategoryType;
 import com.bom.rentalmarket.product.type.MaxPeriodType;
 import com.bom.rentalmarket.product.type.StatusType;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,17 +36,15 @@ public class ProductGetServiceTest {
     int pageNo = 1;
     int pageSize = 10;
 
-    Map<String, Object> products = productService.getProducts(categoryType, statusType, keyword,
-        pageNo, pageSize);
-    boolean hasNextPage = (boolean) products.get("hasNextPage");
+    List<GetProductForm> productList = productService.getProducts(categoryType, statusType, keyword,
+        (long)pageNo, (long)pageSize);
 
     // then
-    List<GetProductForm> productList = (List<GetProductForm>) products.get("productList");
+
 
     // then
-    assertNotNull(products); // products map 객체가 null이 아닌지 확인
+    assertNotNull(productList); // products map 객체가 null이 아닌지 확인
     assertEquals(3, productList.size()); // productList의 크기가 3인지 확인 - 더미 데이터는 위의 조건은 3개임
-    assertFalse(hasNextPage); // hasNextPage가 false인지 확인, 다음 page가 없기때문에 false
 
     assertEquals("test1@naver.com", productList.get(0).getSellerId());
     assertEquals("test12", productList.get(0).getNickname());


### PR DESCRIPTION
1. Controller - Post
- entity 노출을 안하기위해서 form으로 대체
- 이미지파일 확장자 체크 서비스 레이어로 옮김

2. Controller - Get
- 페이지네이션에서 다음페이지 존재유무 리턴 삭제

3. ProductBoard Entity
- @ElementCollection 삭제
- @Convert 적용
- StringListConverter 클래스 만듬 (list -> string)

4. Get 요청 테스트코드 변경
- Map -> List

5. ProductService
- 이미지 확장자 체크 로직 메서드로 분리해서 사용
- 데이터베이스 저장 후 프론트에 전달을 위해 form형식으로 다시 가져옴
- 기존의 QproductBoard 로직부분 Repository로 옮김

6. ProductSearch
- interface를 만들고, searchimpl 클래스에 로직 이동