### PR TITLE
[213]-Rental-History_GetHistory, ChatRoom 삭제된 import 정리

### DIFF
--- a/src/main/java/com/bom/rentalmarket/chatting/controller/ChatRoomController.java
+++ b/src/main/java/com/bom/rentalmarket/chatting/controller/ChatRoomController.java
@@ -1,11 +1,9 @@
 package com.bom.rentalmarket.chatting.controller;
 
 import com.bom.rentalmarket.chatting.domain.chat.ChatListDto;
-import com.bom.rentalmarket.chatting.domain.chat.ChatMessageForm;
 import com.bom.rentalmarket.chatting.domain.chat.ChatRoomDetailDto;
 import com.bom.rentalmarket.chatting.domain.chat.CreateRoomForm;
 import com.bom.rentalmarket.chatting.domain.chat.ReturnProductForm;
-import com.bom.rentalmarket.chatting.domain.chat.TransactionMessageForm;
 import com.bom.rentalmarket.chatting.service.ChatRoomService;
 import com.bom.rentalmarket.jwt.JwtTokenProvider;
 import java.util.List;

--- a/src/main/java/com/bom/rentalmarket/chatting/service/ChatRoomService.java
+++ b/src/main/java/com/bom/rentalmarket/chatting/service/ChatRoomService.java
@@ -8,7 +8,6 @@ import com.bom.rentalmarket.chatting.domain.chat.ChatListDto;
 import com.bom.rentalmarket.chatting.domain.chat.ChatMessageForm;
 import com.bom.rentalmarket.chatting.domain.chat.ChatRoomDetailDto;
 import com.bom.rentalmarket.chatting.domain.chat.ReturnProductForm;
-import com.bom.rentalmarket.chatting.domain.chat.TransactionMessageForm;
 import com.bom.rentalmarket.chatting.domain.model.ChatMessage;
 import com.bom.rentalmarket.chatting.domain.model.ChatRoom;
 import com.bom.rentalmarket.chatting.domain.model.RegisterRoom;

--- a/src/main/java/com/bom/rentalmarket/product/controller/ProductController.java
+++ b/src/main/java/com/bom/rentalmarket/product/controller/ProductController.java
@@ -98,7 +98,7 @@ public class ProductController {
       @RequestParam(required = false, defaultValue = "10") int size) {
 
     List<GetRentalHistoryForm> productList = productService.getBuyerRentalHistory(userId,
-        page, size);
+        (long) page, (long) size);
 
     return ResponseEntity.ok().body(productList);
   }
@@ -110,7 +110,7 @@ public class ProductController {
       @RequestParam(required = false, defaultValue = "10") int size) {
 
     List<GetRentalHistoryForm> productList = productService.getSellerRentalHistory(sellerId,
-        page, size);
+        (long) page, (long) size);
 
     return ResponseEntity.ok().body(productList);
   }
@@ -119,7 +119,7 @@ public class ProductController {
   public ResponseEntity<RentalHistoryDetail> rentalHistoryDetail (
       @PathVariable Long id) {
 
-    RentalHistoryDetail rentalHistoryDetail = productService.retalHistoryDetail(id);
+    RentalHistoryDetail rentalHistoryDetail = productService.rentalHistoryDetail(id);
 
     return ResponseEntity.ok().body(rentalHistoryDetail);
   }


### PR DESCRIPTION
1. ProductService
 - 기존의 무한스크롤적용 안되던거 QueryDSL로 다시 재구성
 - 나중에 리팩토링 해야됨
 - createProdudct에서 불필요한 라인 삭제
  - List<MultipartFile> validImageFiles = new ArrayList<>(); 삭제
  - System.out.println(optionalSeller); 삭제
  - validImageFiles.add(file); 삭제

2. ProductController
 - page, size parse int -> long 적용
 - 그 밖에 오타수정

3. ChatRoomController
 - import com.bom.rentalmarket.chatting.domain.chat.TransactionMessageForm; 삭제
 - import com.bom.rentalmarket.chatting.domain.chat.ChatMessageForm; 삭제

4. ChatRoomService
 - import com.bom.rentalmarket.chatting.domain.chat.TransactionMessageForm; 삭제